### PR TITLE
fix(options): nuxt options used in directive + merge overrides

### DIFF
--- a/nuxt/index.js
+++ b/nuxt/index.js
@@ -15,12 +15,18 @@ Usage:
 */
 
 const { resolve } = require('path');
-const merge = require('lodash.merge')
+const mergeWith = require('lodash.mergewith');
+const isArray = require('lodash.isarray');
 import { FILTER_BASIC } from '../src'
 
-module.exports = function nuxtVSanitizeModule () {
+const mergeCustomizer = (objValue, srcValue) =>
+    isArray(objValue) ? srcValue : undefined;
+const mergeOptions = (defaults, userOpt) =>
+    mergeWith({}, defaults, userOpt, mergeCustomizer);
+
+module.exports = function nuxtVSanitizeModule() {
   const { sanitize = {} } = this.options;
-  const options = merge({}, FILTER_BASIC, sanitize)
+  const options = mergeOptions(FILTER_BASIC, sanitize);
 
   this.addPlugin({
     src: resolve(__dirname, 'v-sanitize-plugin.template.js'),

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   "author": "Chantouch Sek <chantouchsek.cs83@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "lodash.merge": "^4.6.2",
+    "lodash.isarray": "^4.0.0",
+    "lodash.mergewith": "^4.6.2",
     "sanitize-html": "^2.1.1"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -35,13 +35,13 @@ const VSanitize = {
           if (binding.modifiers.strip) {
             el.innerHTML = sanitizeHtml(binding.value, FILTER_STRIP)
           } else if (binding.modifiers.basic) {
-            el.innerHTML = sanitizeHtml(binding.value)
+            el.innerHTML = sanitizeHtml(binding.value, defaultOptions)
           } else if (binding.modifiers.inline) {
             el.innerHTML = sanitizeHtml(binding.value, FILTER_INLINE)
           } else if (binding.modifiers.nothing) {
             el.innerHTML = sanitizeHtml(binding.value, FILTER_NOTHING)
           } else {
-            el.innerHTML = sanitizeHtml(binding.value)
+            el.innerHTML = sanitizeHtml(binding.value, defaultOptions)
           }
         }
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2799,6 +2799,11 @@ lodash._reinterpolate@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
   integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
 
+lodash.isarray@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-4.0.0.tgz#2aca496b28c4ca6d726715313590c02e6ea34403"
+  integrity sha1-KspJayjEym1yZxUxNZDALm6jRAM=
+
 lodash.ismatch@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz#756cb5150ca3ba6f11085a78849645f188f85f37"
@@ -2808,6 +2813,11 @@ lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash.mergewith@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz#617121f89ac55f59047c7aec1ccd6654c6590f55"
+  integrity sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==
 
 lodash.template@^4.0.2:
   version "4.5.0"
@@ -3247,9 +3257,9 @@ path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
 path-parse@^1.0.6:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
-  integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
+  integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
 
 path-type@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
First of all thanks for your package: it's easy to use and clear.

This PR is a fix I made when I realized nuxt options in `nuxt.config.ts` are not really taken into account when using the directive.

This is due to the fact that they where not included in [the sanitize-html method call](https://github.com/chantouchsek/v-sanitize/compare/master...Kampaay:master#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556R38).

Furthermore, the option merge strategy were not doing what expected IMHO since if in the `nuxt.config.ts` I declare for instance:

```
sanitize: {
    allowedTags: ['a'],
    allowedAttributes: {
      a: ['href'],
    },
  }
```

merge result will just replace the first element of default `allowedTags` with `a` while it would be more useful to totally replace `allowedTags` entry with the user-defined one.

Hope this is welcome.
Lorenzo